### PR TITLE
feat: Add time band relationship to Appointment model and update tests

### DIFF
--- a/src/main/kotlin/com/ctrlhub/core/projects/appointments/response/Appointment.kt
+++ b/src/main/kotlin/com/ctrlhub/core/projects/appointments/response/Appointment.kt
@@ -5,7 +5,9 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.github.jasminb.jsonapi.StringIdHandler
 import com.github.jasminb.jsonapi.annotations.Id
+import com.github.jasminb.jsonapi.annotations.Relationship
 import com.github.jasminb.jsonapi.annotations.Type
+import com.ctrlhub.core.settings.timebands.response.TimeBand
 
 @Type("appointments")
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -17,7 +19,9 @@ class Appointment @JsonCreator constructor(
     @JsonProperty("notes") val notes: String = "",
     @JsonProperty("on_ecr") val onEcr: Boolean = false,
     @JsonProperty("on_ecr_notes") val onEcrNotes: String = "",
-    @JsonProperty("start_time") val startTime: String = ""
+    @JsonProperty("start_time") val startTime: String = "",
+    @Relationship("time_band")
+    var timeBand: TimeBand? = null
 ) {
     constructor() : this(
         id = "",
@@ -27,6 +31,7 @@ class Appointment @JsonCreator constructor(
         notes = "",
         onEcr = false,
         onEcrNotes = "",
-        startTime = ""
+        startTime = "",
+        timeBand = null
     )
 }

--- a/src/main/kotlin/com/ctrlhub/core/projects/operations/response/Operation.kt
+++ b/src/main/kotlin/com/ctrlhub/core/projects/operations/response/Operation.kt
@@ -5,6 +5,7 @@ import com.ctrlhub.core.geo.Property
 import com.ctrlhub.core.projects.appointments.response.Appointment
 import com.ctrlhub.core.projects.operations.templates.response.OperationTemplate
 import com.ctrlhub.core.projects.response.Label
+import com.ctrlhub.core.settings.timebands.response.TimeBand
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
@@ -68,4 +69,3 @@ data class OperationFormRequirement(
     @JsonProperty("id") val formId: String,
     @JsonProperty("required") val required: Boolean
 )
-

--- a/src/test/kotlin/com/ctrlhub/core/projects/operations/OperationsRouterTest.kt
+++ b/src/test/kotlin/com/ctrlhub/core/projects/operations/OperationsRouterTest.kt
@@ -135,6 +135,10 @@ class OperationsRouterTest {
             assertEquals("appointment-1", appointment?.id)
             assertEquals("2025-08-15T07:00:00Z", appointment?.startTime)
             assertEquals("2025-08-15T11:00:00Z", appointment?.endTime)
+
+            // Validate the timeband relationship is hydrated (just the ID)
+            assertNotNull(appointment?.timeBand, "TimeBand should not be null")
+            assertEquals("timeband-1", appointment?.timeBand?.id)
         }
     }
 }


### PR DESCRIPTION
Note: Although we are not including timeband data with tests, this relationship is necessary in order to read the ID of a timeband returned with appointment data.

This pull request introduces support for a new `timeBand` relationship on the `Appointment` model, allowing appointments to be associated with a `TimeBand` object. The changes include updating the model, adjusting its constructor, and adding a unit test to ensure the relationship is properly hydrated.

**Model enhancements:**

* Added a nullable `timeBand` property of type `TimeBand` to the `Appointment` class, annotated with `@Relationship("time_band")`, and updated the constructor and default values accordingly. [[1]](diffhunk://#diff-6f8d3ffd4d0d4dbac9ab081baf2f4992e36634abce81c6099c30ca09390c4987R8-R10) [[2]](diffhunk://#diff-6f8d3ffd4d0d4dbac9ab081baf2f4992e36634abce81c6099c30ca09390c4987L20-R24) [[3]](diffhunk://#diff-6f8d3ffd4d0d4dbac9ab081baf2f4992e36634abce81c6099c30ca09390c4987L30-R35)
* Imported `TimeBand` where necessary to support the new relationship.

**Testing:**

* Updated `OperationsRouterTest` to assert that the `timeBand` relationship is hydrated and contains the expected ID.