### PR TITLE
fix: Update TimeBandsRouter endpoint URL

### DIFF
--- a/src/main/kotlin/com/ctrlhub/core/settings/timebands/TimeBandsRouter.kt
+++ b/src/main/kotlin/com/ctrlhub/core/settings/timebands/TimeBandsRouter.kt
@@ -23,7 +23,7 @@ class TimeBandsRouter(httpClient: HttpClient) : Router(httpClient) {
         organisationId: String,
         requestParameters: TimeBandsRequestParameters = TimeBandsRequestParameters()
     ): List<TimeBand> {
-        val endpoint = "/orgs/$organisationId/settings/time-bands"
+        val endpoint = "/v3/orgs/$organisationId/settings/time-bands"
         return fetchJsonApiResources(endpoint, requestParameters.toMap())
     }
 


### PR DESCRIPTION
This pull request updates the API endpoint used in the `TimeBandsRouter` to ensure requests are made to the correct versioned path.

API endpoint update:

* Changed the `endpoint` in the `getTimeBands` method of `TimeBandsRouter` from `/orgs/$organisationId/settings/time-bands` to `/v3/orgs/$organisationId/settings/time-bands` to target the version 3 API.