### PR TITLE
fix: Update TimeBandsRouter URL in getOne

### DIFF
--- a/src/main/kotlin/com/ctrlhub/core/settings/timebands/TimeBandsRouter.kt
+++ b/src/main/kotlin/com/ctrlhub/core/settings/timebands/TimeBandsRouter.kt
@@ -38,7 +38,7 @@ class TimeBandsRouter(httpClient: HttpClient) : Router(httpClient) {
         timeBandId: String,
         requestParameters: TimeBandsRequestParameters = TimeBandsRequestParameters()
     ): TimeBand {
-        val endpoint = "/orgs/$organisationId/settings/time-bands/$timeBandId"
+        val endpoint = "/v3/orgs/$organisationId/settings/time-bands/$timeBandId"
         return fetchJsonApiResource(endpoint, requestParameters.toMap(), TimeBand::class.java)
     }
 }


### PR DESCRIPTION
Sorry - missed the getOne method here - same fix as the previous PR.