### PR TITLE
feat: enhance filter options handling in request parameters

### DIFF
--- a/src/main/kotlin/com/ctrlhub/core/router/request/RequestParameters.kt
+++ b/src/main/kotlin/com/ctrlhub/core/router/request/RequestParameters.kt
@@ -1,7 +1,7 @@
 package com.ctrlhub.core.router.request
 
 data class FilterOption(
-    val field: String?,
+    val field: String? = null,
     val value: String
 )
 

--- a/src/test/kotlin/com/ctrlhub/core/router/request/RequestParametersTest.kt
+++ b/src/test/kotlin/com/ctrlhub/core/router/request/RequestParametersTest.kt
@@ -1,0 +1,69 @@
+package com.ctrlhub.core.router.request
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+private enum class TestIncludes(private val v: String) : JsonApiIncludes {
+    AUTHOR("author"), FORM("form");
+    override fun value() = v
+}
+
+class RequestParametersTest {
+
+    @Test
+    fun `toMap includes offset and limit`() {
+        val request = RequestParameters(offset = 5, limit = 25)
+        val map = request.toMap()
+
+        assertEquals("5", map["offset"])
+        assertEquals("25", map["limit"])
+    }
+
+    @Test
+    fun `single filter option produces filter key`() {
+        val request = RequestParameters(
+            filterOptions = listOf(FilterOption("status", "open"))
+        )
+
+        val map = request.toMap()
+        assertEquals("open", map["filter[status]"])
+    }
+
+    @Test
+    fun `multiple filter options for same field are appended with comma`() {
+        val request = RequestParameters(
+            filterOptions = listOf(
+                FilterOption("status", "open"),
+                FilterOption("status", "closed"),
+            )
+        )
+
+        val map = request.toMap()
+        assertEquals("open,closed", map["filter[status]"])
+    }
+
+    @Test
+    fun `anonymous filter options append to filter key`() {
+        val request = RequestParameters(
+            filterOptions = listOf(
+                FilterOption(null, "a"),
+                FilterOption(null, "b")
+            )
+        )
+
+        val map = request.toMap()
+        assertEquals("a,b", map["filter"])
+    }
+
+    @Test
+    fun `includes are serialized when using RequestParametersWithIncludes`() {
+        val request = RequestParametersWithIncludes<TestIncludes>(
+            includes = listOf(TestIncludes.AUTHOR, TestIncludes.FORM)
+        )
+
+        val map = request.toMap()
+        assertNotNull(map["include"]) // something present
+        assertEquals("author,form", map["include"])
+    }
+}


### PR DESCRIPTION
This pull request updates the handling of filter parameters in the `RequestParameters` classes to support multiple filters per field and anonymous filters, and adds comprehensive unit tests to verify the new behavior. The changes improve flexibility in constructing query parameters and ensure correctness through testing.

**Improvements to filter parameter handling:**

* Modified the `FilterOption` data class so that the `field` property can be nullable, allowing for anonymous filters.
* Updated the `toMap` method in `AbstractRequestParameters` to:
  * Use the key `filter[field]` when a field is specified, or `filter` for anonymous filters.
  * Append multiple filter values for the same field (or anonymous filters) as a comma-separated list.

**Testing enhancements:**

* Added a new test suite `RequestParametersTest` with tests covering offset/limit serialization, single and multiple filter options, anonymous filters, and includes serialization for `RequestParametersWithIncludes`.