### PR TITLE
fix: sometimes mime type is null. Use a default if so

### DIFF
--- a/src/main/kotlin/com/ctrlhub/core/media/ImagesRouter.kt
+++ b/src/main/kotlin/com/ctrlhub/core/media/ImagesRouter.kt
@@ -16,6 +16,7 @@ import io.ktor.client.plugins.ClientRequestException
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import java.io.File
+import java.net.URLConnection
 import java.nio.file.Files
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
@@ -93,7 +94,8 @@ class ImagesRouter(httpClient: HttpClient): Router(httpClient) {
 
         return try {
             val bytes = image.readBytes()
-            val mimeType = Files.probeContentType(image.toPath())
+            val mimeType = URLConnection.guessContentTypeFromName(image.name)
+                ?: "image/png"
             val base64Data = Base64.encode(bytes)
             val dataUri = "data:$mimeType;base64,$base64Data"
 


### PR DESCRIPTION
This pull request makes a minor improvement to the way image MIME types are determined in the `ImagesRouter` class. Instead of using `Files.probeContentType`, it now uses `URLConnection.guessContentTypeFromName`, providing a fallback to `"image/png"` if the type cannot be determined.

- **Image MIME Type Detection:**
  * Changed MIME type detection in `ImagesRouter` from `Files.probeContentType` to `URLConnection.guessContentTypeFromName`, improving reliability and adding a default fallback to `"image/png"` if the type is unknown.
  * Added import for `java.net.URLConnection` to support the new MIME type detection method.