### PR TITLE
fix: filter request parameters

### DIFF
--- a/src/main/kotlin/com/ctrlhub/core/assets/equipment/EquipmentRouter.kt
+++ b/src/main/kotlin/com/ctrlhub/core/assets/equipment/EquipmentRouter.kt
@@ -28,9 +28,9 @@ enum class EquipmentIncludes(val value: String) : JsonApiIncludes {
 class EquipmentRequestParameters(
     offset: Int = 0,
     limit: Int = 100,
-    filterOptions: List<FilterOption> = emptyList(),
+    filters: List<FilterOption> = emptyList(),
     includes: List<EquipmentIncludes> = emptyList()
-) : RequestParametersWithIncludes<EquipmentIncludes>(offset, limit, filterOptions, includes)
+) : RequestParametersWithIncludes<EquipmentIncludes>(offset, limit, filters, includes)
 
 enum class EquipmentSort(val value: String) {
     Name("name");

--- a/src/main/kotlin/com/ctrlhub/core/assets/equipment/exposures/EquipmentExposuresRouter.kt
+++ b/src/main/kotlin/com/ctrlhub/core/assets/equipment/exposures/EquipmentExposuresRouter.kt
@@ -25,9 +25,9 @@ enum class EquipmentExposureIncludes(val value: String) : JsonApiIncludes {
 class EquipmentExposureRequestParameters(
     offset: Int = 0,
     limit: Int = 100,
-    filterOptions: List<FilterOption> = emptyList(),
+    filters: List<FilterOption> = emptyList(),
     includes: List<EquipmentExposureIncludes> = emptyList()
-) : RequestParametersWithIncludes<EquipmentExposureIncludes>(offset, limit, filterOptions, includes)
+) : RequestParametersWithIncludes<EquipmentExposureIncludes>(offset, limit, filters, includes)
 
 /**
  * An equipment exposure router that deals with the exposures realm of the Ctrl Hub API

--- a/src/main/kotlin/com/ctrlhub/core/assets/vehicles/VehiclesRouter.kt
+++ b/src/main/kotlin/com/ctrlhub/core/assets/vehicles/VehiclesRouter.kt
@@ -32,9 +32,9 @@ enum class VehicleIncludes(val value: String) : JsonApiIncludes {
 class VehicleRequestParameters(
     offset: Int = 0,
     limit: Int = 100,
-    filterOptions: List<FilterOption> = emptyList(),
+    filters: List<FilterOption> = emptyList(),
     includes: List<VehicleIncludes> = emptyList()
-) : RequestParametersWithIncludes<VehicleIncludes>(offset, limit, filterOptions, includes)
+) : RequestParametersWithIncludes<VehicleIncludes>(offset, limit, filters, includes)
 
 /**
  * A vehicles router that deals with the vehicles realm of the Ctrl Hub API

--- a/src/main/kotlin/com/ctrlhub/core/projects/operations/OperationsRouter.kt
+++ b/src/main/kotlin/com/ctrlhub/core/projects/operations/OperationsRouter.kt
@@ -27,9 +27,9 @@ enum class OperationIncludes(val value: String) : JsonApiIncludes {
 class OperationRequestParameters(
     offset: Int = 0,
     limit: Int = 100,
-    filterOptions: List<FilterOption> = emptyList(),
+    filters: List<FilterOption> = emptyList(),
     includes: List<OperationIncludes> = emptyList()
-) : RequestParametersWithIncludes<OperationIncludes>(offset, limit, filterOptions, includes)
+) : RequestParametersWithIncludes<OperationIncludes>(offset, limit, filters, includes)
 
 class OperationsRouter(httpClient: HttpClient) : Router(httpClient) {
 

--- a/src/main/kotlin/com/ctrlhub/core/projects/schemes/SchemesRouter.kt
+++ b/src/main/kotlin/com/ctrlhub/core/projects/schemes/SchemesRouter.kt
@@ -23,9 +23,9 @@ enum class SchemeIncludes(val value: String): JsonApiIncludes {
 class SchemeRequestParameters(
     offset: Int = 0,
     limit: Int = 100,
-    filterOptions: List<FilterOption> = emptyList(),
+    filters: List<FilterOption> = emptyList(),
     includes: List<SchemeIncludes> = emptyList()
-) : RequestParametersWithIncludes<SchemeIncludes>(offset, limit, filterOptions, includes)
+) : RequestParametersWithIncludes<SchemeIncludes>(offset, limit, filters, includes)
 
 class SchemesRouter(httpClient: HttpClient) : Router(httpClient) {
 

--- a/src/main/kotlin/com/ctrlhub/core/router/request/FilterExpression.kt
+++ b/src/main/kotlin/com/ctrlhub/core/router/request/FilterExpression.kt
@@ -4,11 +4,8 @@ sealed interface FilterOption {
     fun format(): String
 }
 
-class FieldFilterExpression(val field: String, val values: List<String>) : FilterOption {
-    override fun format(): String {
-        val quoted = values.joinToString(",") { "'${it}'" }
-        return "${field}($quoted)"
-    }
+class FieldFilterExpression(val field: String, val value: String) : FilterOption {
+    override fun format(): String = "${field}('$value')"
 }
 
 class ValueFilterExpression(val value: String) : FilterOption {

--- a/src/main/kotlin/com/ctrlhub/core/router/request/RequestParameters.kt
+++ b/src/main/kotlin/com/ctrlhub/core/router/request/RequestParameters.kt
@@ -27,8 +27,8 @@ abstract class AbstractRequestParameters(
 class RequestParameters(
     offset: Int? = null,
     limit: Int? = null,
-    filterOptions: List<FilterOption> = emptyList()
-) : AbstractRequestParameters(offset, limit, filterOptions)
+    filters: List<FilterOption> = emptyList()
+) : AbstractRequestParameters(offset, limit, filters)
 
 open class RequestParametersWithIncludes<TIncludes>(
     offset: Int? = null,

--- a/src/main/kotlin/com/ctrlhub/core/settings/timebands/TimeBandsRouter.kt
+++ b/src/main/kotlin/com/ctrlhub/core/settings/timebands/TimeBandsRouter.kt
@@ -10,8 +10,8 @@ import io.ktor.client.HttpClient
 class TimeBandsRequestParameters(
     offset: Int? = 0,
     limit: Int? = 100,
-    filterOptions: List<FilterOption> = emptyList()
-) : AbstractRequestParameters(offset, limit, filterOptions)
+    filters: List<FilterOption> = emptyList()
+) : AbstractRequestParameters(offset, limit, filters)
 
 class TimeBandsRouter(httpClient: HttpClient) : Router(httpClient) {
     /**

--- a/src/test/kotlin/com/ctrlhub/core/router/request/RequestParametersFiltersTest.kt
+++ b/src/test/kotlin/com/ctrlhub/core/router/request/RequestParametersFiltersTest.kt
@@ -9,8 +9,8 @@ class RequestParametersFiltersTest {
     fun `and of two field expressions formats correctly`() {
         val expr = AndExpression(
             listOf(
-                FieldFilterExpression("status", listOf("open")),
-                FieldFilterExpression("category", listOf("news"))
+                FieldFilterExpression("status", "open"),
+                FieldFilterExpression("category", "news")
             )
         )
 
@@ -39,7 +39,7 @@ class RequestParametersFiltersTest {
     fun `mixed and expression with field and function`() {
         val expr = AndExpression(
             listOf(
-                FieldFilterExpression("status", listOf("active")),
+                FieldFilterExpression("status", "active"),
                 ValueFilterExpression("is_latest()")
             )
         )

--- a/src/test/kotlin/com/ctrlhub/core/router/request/RequestParametersFiltersTest.kt
+++ b/src/test/kotlin/com/ctrlhub/core/router/request/RequestParametersFiltersTest.kt
@@ -14,7 +14,7 @@ class RequestParametersFiltersTest {
             )
         )
 
-        val params = RequestParameters(filterOptions = listOf(expr))
+        val params = RequestParameters(filters = listOf(expr))
         val map = params.toMap()
 
         assertEquals("and(status('open'),category('news'))", map["filter"])
@@ -29,7 +29,7 @@ class RequestParametersFiltersTest {
             )
         )
 
-        val params = RequestParameters(filterOptions = listOf(expr))
+        val params = RequestParameters(filters = listOf(expr))
         val map = params.toMap()
 
         assertEquals("and(is_latest(),no_start())", map["filter"])
@@ -44,7 +44,7 @@ class RequestParametersFiltersTest {
             )
         )
 
-        val params = RequestParameters(filterOptions = listOf(expr))
+        val params = RequestParameters(filters = listOf(expr))
         val map = params.toMap()
 
         assertEquals("and(status('active'),is_latest())", map["filter"])


### PR DESCRIPTION
This pull request refactors filter-related parameters and expressions across several request classes to improve naming consistency and simplify filter usage. The main changes include renaming the `filterOptions` parameter to `filters` throughout the codebase and updating the `FieldFilterExpression` to accept a single value instead of a list. Related tests have been updated accordingly.

**Parameter Renaming and Consistency:**

* Renamed the `filterOptions` parameter to `filters` in all relevant request parameter classes, such as `RequestParameters`, `RequestParametersWithIncludes`, and their subclasses (e.g., `EquipmentRequestParameters`, `VehicleRequestParameters`, etc.), to improve naming consistency. All constructor usages and superclass calls were updated to match. [[1]](diffhunk://#diff-4e7e84acce05134fdfac8cd06ddd7aa3c086d2563878608abe4f168ee6ba715aL30-R31) [[2]](diffhunk://#diff-5ff46aefe3519f3091135adea31d64237107eb1c93bea6248c01747431dc5b9dL31-R33) [[3]](diffhunk://#diff-7a2e1fab7536d421a980aa2209e96ace62bc06a98c493922609ef8fe3add68faL35-R37) [[4]](diffhunk://#diff-86c316571e5ac0672b7e25988744552a24cf33262b924755bb17c0089d8d7fbbL28-R30) [[5]](diffhunk://#diff-3cc0e222d7cf6259245ecf70364614bf5b79c7a2bfc4919583c19cf1ebdc2f0aL30-R32) [[6]](diffhunk://#diff-5a775c1d7b4c40b7c0e69b4cf77393d0d3717bf227a782cc3ce747189ef9ba20L26-R28) [[7]](diffhunk://#diff-573aedaa9abf9e98ce540048c38fb7d0d8fe9517426a5be5950a07cbc89a3731L13-R14)

**Filter Expression Simplification:**

* Changed `FieldFilterExpression` to accept a single `value: String` instead of a list of values, and updated its `format()` method to reflect this change.

**Test Updates:**

* Updated all usages of `FieldFilterExpression` in `RequestParametersFiltersTest` to use a single value, and replaced `filterOptions` with `filters` in test parameter construction to align with the new API. [[1]](diffhunk://#diff-188542db13e820d8cc6f91a22379eaab3788b496024d950ebfc983715d4b5842L12-R17) [[2]](diffhunk://#diff-188542db13e820d8cc6f91a22379eaab3788b496024d950ebfc983715d4b5842L32-R32) [[3]](diffhunk://#diff-188542db13e820d8cc6f91a22379eaab3788b496024d950ebfc983715d4b5842L42-R47)