### PR TITLE
fix: allow use of a list of values for field filtering, and format

### DIFF
--- a/src/main/kotlin/com/ctrlhub/core/router/request/FilterExpression.kt
+++ b/src/main/kotlin/com/ctrlhub/core/router/request/FilterExpression.kt
@@ -4,8 +4,22 @@ sealed interface FilterOption {
     fun format(): String
 }
 
-class FieldFilterExpression(val field: String, val value: String) : FilterOption {
-    override fun format(): String = "${field}('$value')"
+class FieldFilterExpression<T>(val field: String, val value: T) : FilterOption {
+    private fun quoteIfNeeded(v: Any?): String = when (v) {
+        is String -> "'${v.replace("'", "\\'")}'"
+        null -> "''"
+        else -> v.toString()
+    }
+
+    override fun format(): String {
+        return when (value) {
+            is List<*> -> {
+                val inner = value.joinToString(",") { quoteIfNeeded(it) }
+                "$field($inner)"
+            }
+            else -> "$field(${quoteIfNeeded(value)})"
+        }
+    }
 }
 
 class ValueFilterExpression(val value: String) : FilterOption {
@@ -16,6 +30,7 @@ class AndExpression(val parts: List<FilterOption>) : FilterOption {
     override fun format(): String = "and(${parts.joinToString(",") { it.format() }})"
 }
 
+@Suppress("unused")
 class OrExpression(val parts: List<FilterOption>) : FilterOption {
     override fun format(): String = "or(${parts.joinToString(",") { it.format() }})"
 }

--- a/src/test/kotlin/com/ctrlhub/core/router/request/RequestParametersFiltersTest.kt
+++ b/src/test/kotlin/com/ctrlhub/core/router/request/RequestParametersFiltersTest.kt
@@ -49,5 +49,45 @@ class RequestParametersFiltersTest {
 
         assertEquals("and(status('active'),is_latest())", map["filter"])
     }
-}
 
+    @Test
+    fun `field list formats correctly`() {
+        val ids = listOf(
+            "06e55d1c-f816-48b2-b11b-debdb3115b2f",
+            "5f43b904-8d5b-4b81-9258-b14aafe858d4",
+            "9b31bdd1-2785-4419-b1b3-36ccd35d22c6"
+        )
+
+        val expr = FieldFilterExpression("payload_operations", ids)
+        val params = RequestParameters(filters = listOf(expr))
+        val map = params.toMap()
+
+        assertEquals(
+            "payload_operations('06e55d1c-f816-48b2-b11b-debdb3115b2f','5f43b904-8d5b-4b81-9258-b14aafe858d4','9b31bdd1-2785-4419-b1b3-36ccd35d22c6')",
+            map["filter"]
+        )
+    }
+
+    @Test
+    fun `or of field list and single field formats correctly`() {
+        val ids = listOf(
+            "06e55d1c-f816-48b2-b11b-debdb3115b2f",
+            "5f43b904-8d5b-4b81-9258-b14aafe858d4"
+        )
+
+        val expr = OrExpression(
+            listOf(
+                FieldFilterExpression("payload_operations", ids),
+                FieldFilterExpression("category", "updates")
+            )
+        )
+
+        val params = RequestParameters(filters = listOf(expr))
+        val map = params.toMap()
+
+        assertEquals(
+            "or(payload_operations('06e55d1c-f816-48b2-b11b-debdb3115b2f','5f43b904-8d5b-4b81-9258-b14aafe858d4'),category('updates'))",
+            map["filter"]
+        )
+    }
+}


### PR DESCRIPTION
This pull request enhances the flexibility and correctness of filter expression formatting in the request router. The main improvements are the addition of support for list values in field filters, improved quoting for string values, and new tests to ensure correct filter formatting, especially for lists and logical expressions.

**Filter expression improvements:**

* Updated `FieldFilterExpression` to support values of any type, including lists, and to properly quote string values and handle nulls. This allows filters like `field('a','b','c')` to be generated when a list is provided.

**Testing enhancements:**

* Added tests to verify that `FieldFilterExpression` formats lists of values correctly in the filter string.
* Added tests to ensure that logical expressions like `OrExpression` work correctly with both list and single field filters, verifying their combined formatting.

**Code quality:**

* Added `@Suppress("unused")` to the `OrExpression` class to prevent warnings about unused code, improving code clarity.