### PR TITLE
task: extract out form submission meta to its own class with defined properties

### DIFF
--- a/src/main/kotlin/com/ctrlhub/core/datacapture/resource/FormSubmissionVersion.kt
+++ b/src/main/kotlin/com/ctrlhub/core/datacapture/resource/FormSubmissionVersion.kt
@@ -13,8 +13,10 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.github.jasminb.jsonapi.StringIdHandler
 import com.github.jasminb.jsonapi.annotations.Id
+import com.github.jasminb.jsonapi.annotations.Meta
 import com.github.jasminb.jsonapi.annotations.Relationship
 import com.github.jasminb.jsonapi.annotations.Type
+import java.time.LocalDateTime
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Type("form-submission-versions")
@@ -31,8 +33,8 @@ class FormSubmissionVersion @JsonCreator constructor(
     @Relationship("schema")
     var schema: FormSchema? = null,
 
-    @JsonProperty("meta")
-    var meta: Map<String, Any>? = null,
+    @Meta
+    var meta: FormSubmissionVersionMeta? = null,
 
     @Relationship("author")
     var author: User? = null,
@@ -57,4 +59,11 @@ class FormSubmissionVersion @JsonCreator constructor(
 
     @Relationship("payload_schemes")
     var payloadSchemes: List<Scheme>? = null,
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+class FormSubmissionVersionMeta(
+    @JsonProperty("created_at") val createdAt: LocalDateTime? = null,
+    @JsonProperty("latest") val latest: String? = null,
+    @JsonProperty("is_latest") val isLatest: Boolean? = null,
 )


### PR DESCRIPTION
This pull request refactors how metadata is handled in the `FormSubmissionVersion` resource. The main change is replacing the generic `meta` map with a strongly-typed `FormSubmissionVersionMeta` class, improving type safety and clarity in the codebase. Additionally, the new class is annotated to support proper JSON serialization/deserialization.

Metadata handling improvements:

* Replaced the generic `meta: Map<String, Any>?` property in `FormSubmissionVersion` with a strongly-typed `meta: FormSubmissionVersionMeta?`, and annotated it with `@Meta` for better JSON:API support. (`src/main/kotlin/com/ctrlhub/core/datacapture/resource/FormSubmissionVersion.kt`)
* Introduced a new `FormSubmissionVersionMeta` class with explicit fields for `createdAt`, `latest`, and `isLatest`, each with appropriate JSON annotations and type safety. (`src/main/kotlin/com/ctrlhub/core/datacapture/resource/FormSubmissionVersion.kt`)

Dependency and import updates:

* Added necessary imports for `@Meta` and `LocalDateTime` to support the new metadata structure. (`src/main/kotlin/com/ctrlhub/core/datacapture/resource/FormSubmissionVersion.kt`)