### PR TITLE
task: add ability to get raw payload instead of a parsed map

### DIFF
--- a/src/main/kotlin/com/ctrlhub/core/datacapture/resource/FormSubmissionVersion.kt
+++ b/src/main/kotlin/com/ctrlhub/core/datacapture/resource/FormSubmissionVersion.kt
@@ -67,9 +67,17 @@ class FormSubmissionVersion @JsonCreator constructor(
     @JsonProperty("resources")
     var resources: List<Map<String, Any>>? = null,
 ) {
+    val rawPayload: String?
+        get() = payload?.let {
+            try {
+                mapper.writeValueAsString(it)
+            } catch (e: Exception) {
+                null
+            }
+        }
 
     // shared Jackson mapper configured to ignore unknown properties when hydrating attribute maps
-    private fun resourceMapper(): ObjectMapper = Companion.mapper
+    private fun resourceMapper(): ObjectMapper = mapper
 
     /**
      * Convert the raw resources list (List<Map<...>>) into typed JsonApiEnvelope objects.

--- a/src/test/kotlin/com/ctrlhub/core/datacapture/FormSubmissionVersionsRouterTest.kt
+++ b/src/test/kotlin/com/ctrlhub/core/datacapture/FormSubmissionVersionsRouterTest.kt
@@ -107,6 +107,14 @@ class FormSubmissionVersionsRouterTest {
             assertNotNull(result.payload)
             assertTrue(result.payload!!.containsKey("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"))
             assertTrue(result.payload!!.containsKey("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"))
+
+            // check rawPayload is a valid JSON string
+            assertNotNull(result.rawPayload)
+            assertTrue(result.rawPayload!!.startsWith("{"))
+            assertTrue(result.rawPayload!!.endsWith("}"))
+            // verify it contains the expected keys in JSON format
+            assertTrue(result.rawPayload!!.contains("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"))
+            assertTrue(result.rawPayload!!.contains("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"))
         }
     }
 
@@ -169,6 +177,14 @@ class FormSubmissionVersionsRouterTest {
             assertNotNull(result.payload)
             assertTrue(result.payload!!.containsKey("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"))
             assertTrue(result.payload!!.containsKey("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"))
+
+            // check rawPayload is a valid JSON string
+            assertNotNull(result.rawPayload)
+            assertTrue(result.rawPayload!!.startsWith("{"))
+            assertTrue(result.rawPayload!!.endsWith("}"))
+            // verify it contains the expected keys in JSON format
+            assertTrue(result.rawPayload!!.contains("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"))
+            assertTrue(result.rawPayload!!.contains("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"))
         }
     }
 }


### PR DESCRIPTION
This pull request introduces a new computed property to the `FormSubmissionVersion` class that exposes the payload as a raw JSON string, and adds corresponding tests to verify its correctness. The main goal is to make it easier to access the payload in its serialized form for downstream use or debugging.

### Feature addition

* Added a computed property `rawPayload` to the `FormSubmissionVersion` class, which serializes the `payload` field to a JSON string using the shared Jackson `ObjectMapper`. This property handles serialization errors gracefully by returning `null` if serialization fails. (`src/main/kotlin/com/ctrlhub/core/datacapture/resource/FormSubmissionVersion.kt`)

### Test coverage

* Extended tests in `FormSubmissionVersionsRouterTest` to verify that `rawPayload` is a valid JSON string, starts and ends with curly braces, and contains the expected keys, ensuring the new property works as intended. (`src/test/kotlin/com/ctrlhub/core/datacapture/FormSubmissionVersionsRouterTest.kt`) [[1]](diffhunk://#diff-d256aee90e58d8f64b232bb79f22bdd312eced4fef95ea6371dea8cd6be3683fR110-R117) [[2]](diffhunk://#diff-d256aee90e58d8f64b232bb79f22bdd312eced4fef95ea6371dea8cd6be3683fR180-R187)