### PR TITLE
fix: add submission relationship to version

### DIFF
--- a/src/main/kotlin/com/ctrlhub/core/datacapture/resource/FormSubmissionVersion.kt
+++ b/src/main/kotlin/com/ctrlhub/core/datacapture/resource/FormSubmissionVersion.kt
@@ -2,6 +2,7 @@ package com.ctrlhub.core.datacapture.resource
 
 import com.ctrlhub.core.datacapture.response.FormSchema
 import com.ctrlhub.core.datacapture.response.Form
+import com.ctrlhub.core.datacapture.response.FormSubmission
 import com.ctrlhub.core.geo.Property
 import com.ctrlhub.core.iam.response.User
 import com.ctrlhub.core.media.response.Image
@@ -35,6 +36,9 @@ class FormSubmissionVersion @JsonCreator constructor(
 
     @Relationship("schema")
     var schema: FormSchema? = null,
+
+    @Relationship("submission")
+    var submission: FormSubmission? = null,
 
     @Meta
     var meta: FormSubmissionVersionMeta? = null,


### PR DESCRIPTION
This pull request introduces a minor update to the `FormSubmissionVersion` data model to improve its ability to reference related data. The most notable change is the addition of a new relationship field.

Enhancement to data relationships:

* Added a `submission` relationship of type `FormSubmission` to the `FormSubmissionVersion` class, allowing direct linkage to the associated form submission.
* Imported the `FormSubmission` type to support the new relationship field in the resource class.