### PR TITLE
fix: drop the data wrapper on a form schema raw content

### DIFF
--- a/src/main/kotlin/com/ctrlhub/core/datacapture/response/FormSchema.kt
+++ b/src/main/kotlin/com/ctrlhub/core/datacapture/response/FormSchema.kt
@@ -42,9 +42,7 @@ data class FormSchema @JsonCreator constructor(
                 "attributes" to attributes
             )
 
-            val envelope = mapOf("data" to dataMap)
-
-            return mapper.writeValueAsString(envelope)
+            return mapper.writeValueAsString(dataMap)
         }
 }
 

--- a/src/test/kotlin/com/ctrlhub/core/datacapture/FormSchemaRawSchemaTest.kt
+++ b/src/test/kotlin/com/ctrlhub/core/datacapture/FormSchemaRawSchemaTest.kt
@@ -36,10 +36,10 @@ class FormSchemaRawSchemaTest {
         // Parse the generated JSON and assert structure
         val node = mapper.readTree(raw)
 
-        assertEquals(id, node["data"]["id"].asText())
-        assertEquals("form-schemas", node["data"]["type"].asText())
+        assertEquals(id, node["id"].asText())
+        assertEquals("form-schemas", node["type"].asText())
 
-        val attributes = node["data"]["attributes"]
+        val attributes = node["attributes"]
         assertEquals(version, attributes["version"].asText())
         assertTrue(attributes["model"]["properties"].has("field-1"))
     }


### PR DESCRIPTION
This pull request updates the JSON serialization format for the `FormSchema` class by removing the outer `"data"` envelope, resulting in a flatter JSON structure. Corresponding unit tests have been updated to reflect this change.

**Serialization format update:**

* The `FormSchema` class's `toRawSchemaJson` method now serializes the schema directly as a flat object, instead of wrapping it in a `"data"` envelope.

**Test adjustments:**

* The `FormSchemaRawSchemaTest` unit test assertions have been updated to match the new flat JSON structure, ensuring fields are accessed at the top level rather than under `"data"`.