### PR TITLE
fix: implement resource hydration using Jasminb ResourceConverter

### DIFF
--- a/src/main/kotlin/com/ctrlhub/core/media/response/Image.kt
+++ b/src/main/kotlin/com/ctrlhub/core/media/response/Image.kt
@@ -9,7 +9,7 @@ import com.github.jasminb.jsonapi.annotations.Type
 
 @Type("images")
 class Image @JsonCreator constructor(
-    @Id(StringIdHandler::class) var id: String = "",
+    @JsonProperty("id") @Id(StringIdHandler::class) var id: String = "",
     @JsonProperty("mime_type") var mimeType: String = "",
     @JsonProperty("extension") var extension: String = "",
     @JsonProperty("width") var width: Int = 0,

--- a/src/test/kotlin/com/ctrlhub/core/datacapture/FormSubmissionVersionResourcesTest.kt
+++ b/src/test/kotlin/com/ctrlhub/core/datacapture/FormSubmissionVersionResourcesTest.kt
@@ -21,7 +21,7 @@ import kotlin.test.assertNotNull
 class FormSubmissionVersionResourcesTest {
 
     @Test
-    fun `can auto-hydrate resources from resources envelope`() {
+    fun `can auto-hydrate resources`() {
         val jsonFilePath = Paths.get("src/test/resources/datacapture/one-form-submission-version-with-resources.json")
         val jsonContent = Files.readString(jsonFilePath)
 
@@ -48,7 +48,7 @@ class FormSubmissionVersionResourcesTest {
             assertNotNull(result.id)
 
             // hydrate image resource
-            val image = result.autoHydrateByIdAs<Image>("c2d3e4f5-2a34-4b8c-e39d-0e1f2a3b4c5d")
+            val image = result.hydrateResourceById("c2d3e4f5-2a34-4b8c-e39d-0e1f2a3b4c5d", Image::class.java)
             assertNotNull(image)
             assertEquals("image/jpeg", image!!.mimeType)
             assertEquals(4000, image.width)
@@ -56,7 +56,7 @@ class FormSubmissionVersionResourcesTest {
             assertEquals(2136986L, image.bytes)
 
             // hydrate operation resource
-            val op = result.autoHydrateByIdAs<Operation>("d2e3f4a5-3b45-4c9d-f4ae-1f2a3b4c5d6e")
+            val op = result.hydrateResourceById("d2e3f4a5-3b45-4c9d-f4ae-1f2a3b4c5d6e", Operation::class.java)
             assertNotNull(op)
             assertEquals("Task 2", op!!.name)
             assertEquals("TK0002", op.code)


### PR DESCRIPTION
This pull request refactors and improves the resource hydration logic in the `FormSubmissionVersion` class, moving from a custom mapping approach to using Jasminb's `ResourceConverter` for JSON:API resource handling. It also removes legacy envelope/data classes, simplifies resource lookup, and updates related tests and models.

**Refactor and improvement of resource hydration:**

* Replaces custom resource mapping logic with Jasminb's `ResourceConverter`, enabling more robust and extensible JSON:API resource hydration in `FormSubmissionVersion`. This includes new helper methods for converter configuration and raw resource lookup.
* Removes legacy `JsonApiEnvelope` and `JsonApiResourceData` classes, as hydration now relies on Jasminb's converter and registered types.

**API and test updates:**

* Updates the public hydration API: introduces `hydrateResourceById(id, clazz)` as the primary method, and updates tests to use this new method instead of the old `autoHydrateByIdAs`. [[1]](diffhunk://#diff-d27b5c8495a76efe023025e982322f6de8dfdd017080410735cf9330df1cf003L86-R170) [[2]](diffhunk://#diff-e9d5dac3321aa597a6c4e22527739cb2abfc74b1d7e440431eb8e2dcbecc0261L51-R59)
* Improves type registry access with a synchronized method to retrieve all registered classes for converter configuration.

**Minor improvements:**

* Adds explicit `@JsonProperty("id")` annotation to the `id` field in the `Image` model for consistency.
* Minor test renaming for clarity.