### PR TITLE
task: overloaded way of creating a form submission version

### DIFF
--- a/src/main/kotlin/com/ctrlhub/core/datacapture/FormSubmissionVersionsRouter.kt
+++ b/src/main/kotlin/com/ctrlhub/core/datacapture/FormSubmissionVersionsRouter.kt
@@ -57,7 +57,7 @@ class FormSubmissionVersionsRouter(httpClient: HttpClient) : Router(httpClient) 
      */
     suspend fun create(schemaId: String, payload: Map<String, Any>): FormSubmissionVersion {
         return postJsonApiResource(
-            "/v3/form-submissions",
+            "/v3/form-submission-versions",
             requestBody = FormSubmissionVersion(
                 payload = payload,
                 id = "",
@@ -86,7 +86,7 @@ class FormSubmissionVersionsRouter(httpClient: HttpClient) : Router(httpClient) 
      */
     suspend fun create(request: CreateSubmissionRequest): FormSubmissionVersion {
         return postJsonApiRequest(
-            "/v3/form-submissions",
+            "/v3/form-submission-versions",
             request.toJsonApiRequest(),
             queryParameters =emptyMap(),
             contentType = ContentType.parse("application/vnd.api+json"),

--- a/src/main/kotlin/com/ctrlhub/core/datacapture/FormSubmissionVersionsRouter.kt
+++ b/src/main/kotlin/com/ctrlhub/core/datacapture/FormSubmissionVersionsRouter.kt
@@ -10,6 +10,7 @@ import com.ctrlhub.core.router.Router
 import io.ktor.client.HttpClient
 import io.ktor.http.ContentType
 import com.ctrlhub.core.api.response.PaginatedList
+import com.ctrlhub.core.datacapture.request.CreateSubmissionRequest
 import com.ctrlhub.core.router.request.FilterOption
 import com.ctrlhub.core.router.request.JsonApiIncludes
 import com.ctrlhub.core.router.request.RequestParametersWithIncludes
@@ -65,6 +66,29 @@ class FormSubmissionVersionsRouter(httpClient: HttpClient) : Router(httpClient) 
                 )
             ),
             queryParameters = emptyMap(),
+            contentType = ContentType.parse("application/vnd.api+json"),
+            FormSubmissionVersion::class.java,
+            FormSchema::class.java
+        )
+    }
+
+    /**
+     * Create a new form submission version using a JSON:API request payload.
+     *
+     * Sends a POST request to create a form submission (and its initial version)
+     * using a fully-constructed JSON:API request body derived from
+     * [CreateSubmissionRequest].
+     *
+     * @param request the submission creation request containing payload data,
+     * schema relationship and optional organisation relationship
+     * @return the created and hydrated [FormSubmissionVersion] instance
+     * @throws Exception on network, serialization or parsing errors
+     */
+    suspend fun create(request: CreateSubmissionRequest): FormSubmissionVersion {
+        return postJsonApiRequest(
+            "/v3/form-submissions",
+            request.toJsonApiRequest(),
+            queryParameters =emptyMap(),
             contentType = ContentType.parse("application/vnd.api+json"),
             FormSubmissionVersion::class.java,
             FormSchema::class.java

--- a/src/main/kotlin/com/ctrlhub/core/datacapture/request/CreateSubmissionRequest.kt
+++ b/src/main/kotlin/com/ctrlhub/core/datacapture/request/CreateSubmissionRequest.kt
@@ -1,0 +1,45 @@
+package com.ctrlhub.core.datacapture.request
+
+import com.ctrlhub.core.router.request.JsonApiRequest
+import com.ctrlhub.core.router.request.RelationshipData
+import com.ctrlhub.core.router.request.ResourceObject
+import com.ctrlhub.core.router.request.SubmissionAttributes
+import com.ctrlhub.core.router.request.ToOneRelationship
+
+data class SubmissionRelationships(
+    val schema: ToOneRelationship,
+    val organisation: ToOneRelationship,
+)
+
+data class CreateSubmissionRequest(
+    val payload: Map<String, Any?>,
+    val organisationId: String,
+    val schemaId: String,
+    val iteration: Int = 0
+) {
+    fun toJsonApiRequest(): JsonApiRequest<ResourceObject<SubmissionAttributes, SubmissionRelationships>> {
+        return JsonApiRequest(
+            ResourceObject(
+                type = "form-submission-versions",
+                attributes = SubmissionAttributes(
+                    payload = payload,
+                    iteration = iteration
+                ),
+                relationships = SubmissionRelationships(
+                    schema = ToOneRelationship(
+                        data = RelationshipData(
+                            type = "form-schemas",
+                            id = schemaId
+                        )
+                    ),
+                    organisation = ToOneRelationship(
+                        data = RelationshipData(
+                            type = "organisations",
+                            id = organisationId
+                        )
+                    )
+                )
+            )
+        )
+    }
+}

--- a/src/main/kotlin/com/ctrlhub/core/router/request/JsonApiRequest.kt
+++ b/src/main/kotlin/com/ctrlhub/core/router/request/JsonApiRequest.kt
@@ -1,0 +1,26 @@
+package com.ctrlhub.core.router.request
+
+data class JsonApiRequest<T>(
+    val data: T
+)
+
+data class ResourceObject<A, R>(
+    val type: String,
+    val id: String? = null,
+    val attributes: A,
+    val relationships: R
+)
+
+data class SubmissionAttributes(
+    val payload: Map<String, Any?>,
+    val iteration: Int
+)
+
+data class ToOneRelationship(
+    val data: RelationshipData
+)
+
+data class RelationshipData(
+    val type: String,
+    val id: String
+)

--- a/src/test/kotlin/com/ctrlhub/core/datacapture/FormSubmissionVersionsRouterTest.kt
+++ b/src/test/kotlin/com/ctrlhub/core/datacapture/FormSubmissionVersionsRouterTest.kt
@@ -3,6 +3,7 @@ package com.ctrlhub.core.datacapture
 import com.ctrlhub.core.configureForTest
 import com.ctrlhub.core.datacapture.resource.FormSubmissionVersion
 import com.ctrlhub.core.api.response.PaginatedList
+import com.ctrlhub.core.datacapture.request.CreateSubmissionRequest
 import io.ktor.client.*
 import io.ktor.client.engine.mock.*
 import io.ktor.http.*
@@ -38,6 +39,44 @@ class FormSubmissionVersionsRouterTest {
                 payload = mapOf("Test" to "value")
             )
 
+            assertIs<FormSubmissionVersion>(result)
+            assertNotNull(result.id)
+        }
+    }
+
+    @Test
+    fun `can create submission using JsonApiRequest`() {
+        // Arrange
+        val responseJsonPath =
+            Paths.get("src/test/resources/datacapture/form-submission-version-response.json")
+        val responseJson = Files.readString(responseJsonPath)
+
+        val mockEngine = MockEngine { _ ->
+            respond(
+                content = responseJson,
+                status = HttpStatusCode.Created,
+                headers = headersOf(
+                    HttpHeaders.ContentType,
+                    "application/vnd.api+json"
+                )
+            )
+        }
+
+        val formSubmissionVersionsRouter = FormSubmissionVersionsRouter(
+            httpClient = HttpClient(mockEngine).configureForTest()
+        )
+
+        val request = CreateSubmissionRequest(
+            schemaId = "89a756e8-97e9-4edb-9c47-f260831c4ab0",
+            organisationId = "org-123",
+            payload = mapOf(
+                "field-1" to "Test value",
+                "field-2" to true
+            )
+        )
+
+        runBlocking {
+            val result = formSubmissionVersionsRouter.create(request)
             assertIs<FormSubmissionVersion>(result)
             assertNotNull(result.id)
         }

--- a/src/test/kotlin/com/ctrlhub/core/router/request/RequestParametersFiltersTest.kt
+++ b/src/test/kotlin/com/ctrlhub/core/router/request/RequestParametersFiltersTest.kt
@@ -17,7 +17,7 @@ class RequestParametersFiltersTest {
         val params = RequestParameters(filters = listOf(expr))
         val map = params.toMap()
 
-        assertEquals("and(eq(status,'open'),eq(category,'news'))", map["filter"])
+        assertEquals("and(eq(status,open),eq(category,news))", map["filter"])
     }
 
     @Test


### PR DESCRIPTION
This PR allows us to create a form submission request using a request object, bypassing the `jasminb` library which does not give us fine control over the request payload.